### PR TITLE
fix: remove stale package entry fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,6 @@
       "require": "./dist/core.cjs"
     }
   },
-  "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "bin": {
     "browserslist-to-es-version": "./dist/cli.js"


### PR DESCRIPTION
## Summary

This PR removes stale `main` and `module` fields from `package.json` because the package already uses `exports` to define its public entry points. The removed `module` field pointed to `dist/index.mjs`, which is not included in the published package.